### PR TITLE
No Caliburn.Xaml.UAP.rd.xml in nuget package

### DIFF
--- a/nuget/Caliburn.Light.nuspec
+++ b/nuget/Caliburn.Light.nuspec
@@ -33,6 +33,7 @@ Third alpha version of next major release
 
     <file src="..\src\Caliburn.Xaml.NET45\bin\Release\Caliburn.*" target="lib\net451" />
     <file src="..\src\Caliburn.Xaml.UAP\bin\Release\Caliburn.*" target="lib\uap10.0" />
+    <file src="..\src\Caliburn.Xaml.UAP\bin\Release\Caliburn.Xaml\Properties\Caliburn.Xaml.UAP.rd.xml" target="lib\uap10.0\Caliburn.Xaml\Properties\Caliburn.Xaml.UAP.rd.xml" />
 
     <file src="tools\**" target="tools" />
 

--- a/src/Caliburn.Xaml.UAP/Caliburn.Xaml.UAP.csproj
+++ b/src/Caliburn.Xaml.UAP/Caliburn.Xaml.UAP.csproj
@@ -27,6 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Caliburn.Xaml.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Caliburn.Xaml.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>


### PR DESCRIPTION
I get the following error during compilation of my Universal Windows app which is using Caliburn.Light: `Could not copy the file "C:\Users\Alex\.nuget\packages\Caliburn.Light\3.0.1-alpha\lib\uap10.0\Caliburn.Xaml\Properties\Caliburn.Xaml.UAP.rd.xml" because it was not found.`

Current pull request should fix this issue.