### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tibel/Caliburn.Light/security/code-scanning/1](https://github.com/tibel/Caliburn.Light/security/code-scanning/1)

To fix the error, we should set a `permissions` block for the job or workflow, specifying only the minimal required permissions. In this CI workflow, the steps are: checking out code, building, and uploading artifacts, none of which need write access to repository contents or elevated privileges. The best practice is to set `contents: read`. The block can be set at the job (`build:`) or workflow root (affecting all jobs). The minimal and recommended change is to add `permissions: contents: read` at the top level, just after the `name:` block, for clarity and maximum effect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
